### PR TITLE
fix incorrectly named binary

### DIFF
--- a/cmd/text_processor/Dockerfile
+++ b/cmd/text_processor/Dockerfile
@@ -15,6 +15,6 @@ ENV DURATION=10
 ENV AUDIO_PROCESSOR_ADDRESS=""
 
 COPY --from=builder /go/src/github.com/kai5263499/diy-jarvis/cmd/text_processor/deps /
-COPY --from=builder /go/src/github.com/kai5263499/diy-jarvis/cmd/text_processor/text_processor /mic_capture
+COPY --from=builder /go/src/github.com/kai5263499/diy-jarvis/cmd/text_processor/text_processor /text_processor
 
 ENTRYPOINT [ "/text_processor" ]


### PR DESCRIPTION
This fixes a copy pasta issue where the binary built in a previous step was added to the final image with the wrong name causing the resulting image to be broken