### PR TITLE
Add Dockerfile and README for slack_bot

### DIFF
--- a/cmd/slack_bot/Dockerfile
+++ b/cmd/slack_bot/Dockerfile
@@ -1,0 +1,20 @@
+FROM kai5263499/diy-jarvis-builder as builder
+
+COPY / /go/src/github.com/kai5263499/diy-jarvis
+
+RUN cd /go/src/github.com/kai5263499/diy-jarvis/cmd/slack_bot && \
+    go build && \
+    ldd slack_bot | tr -s '[:blank:]' '\n' | grep '^/' | \
+    xargs -I % sh -c 'mkdir -p $(dirname deps%); cp % deps%;'
+
+FROM scratch
+
+LABEL MAINTAINER="Wes Widner <kai5263499@gmail.com>"
+
+ENV SLACK_TOKEN=""
+ENV TEXT_PROCESSOR_ADDRESS=""
+
+COPY --from=builder /go/src/github.com/kai5263499/diy-jarvis/cmd/slack_bot/deps /
+COPY --from=builder /go/src/github.com/kai5263499/diy-jarvis/cmd/slack_bot/slack_bot /slack_bot
+
+ENTRYPOINT [ "/slack_bot" ]

--- a/cmd/slack_bot/README.md
+++ b/cmd/slack_bot/README.md
@@ -1,0 +1,3 @@
+# slack_bot
+
+This is a service that pipes text from Slack over to a text processing service


### PR DESCRIPTION
This adds a Dockerfile and README for slack_bot. Making it possible to create a Docker pipeline for this service